### PR TITLE
슬라이드 width값 수정

### DIFF
--- a/_posts/2018-06-11-tfpattern-week2.md
+++ b/_posts/2018-06-11-tfpattern-week2.md
@@ -20,9 +20,15 @@ share: true
 - TFRecord
 - Queue
 - Multi Thread / Coordinator / QueueRunner
-```            
+```
 #### Slide
-<iframe src="https://docs.google.com/presentation/d/e/2PACX-1vS1XZSl4WFEELAf9V1TLehuT0oCufbY-dIC9TxKg5MVMGhn9p1vZ4Z_QX2EZZt-1Q5P7msOGmMAzuqB/embed?start=true&loop=false&delayms=10000" frameborder="0" width="960" height="569" allowfullscreen="true" mozallowfullscreen="true" webkitallowfullscreen="true"></iframe>
+<style>
+.responsive-wrap iframe{ max-width: 100%;}
+</style>
+<div class="responsive-wrap">
+<!-- this is the embed code provided by Google -->
+<iframe src="https://docs.google.com/presentation/d/e/2PACX-1vS1XZSl4WFEELAf9V1TLehuT0oCufbY-dIC9TxKg5MVMGhn9p1vZ4Z_QX2EZZt-1Q5P7msOGmMAzuqB/embed?start=true&loop=false&delayms=10000" frameborder="0" width="960" height="480" allowfullscreen="true" mozallowfullscreen="true" webkitallowfullscreen="true"></iframe>
+</div>
 
 ## 발표2: TF fundamental, Code structure overview, TF Pattern design philosophy, and Lack Lenet5 Tf model
 **Speaker : Jaewook Kang**
@@ -57,9 +63,16 @@ share: true
 - 성능 측정 모델 + 모델 훈련시키기 -> `trainer.py`
 - 모델 평가하기 -> `eval.py`
 ```
-    
+
 #### Slide
-<iframe src="https://docs.google.com/presentation/d/e/2PACX-1vT1zTUU36nekwbv7kKwPYTMn-CGbX-7B3Yfz_dzBmb0nOrkM1kqXBtDZRnFIXH_UNmhj2dbuY8gE8Ze/embed?start=true&loop=false&delayms=10000" frameborder="0" width="960" height="749" allowfullscreen="true" mozallowfullscreen="true" webkitallowfullscreen="true"></iframe>
+<style>
+.responsive-wrap iframe{ max-width: 100%;}
+</style>
+<div class="responsive-wrap">
+<!-- this is the embed code provided by Google -->
+<iframe src="https://docs.google.com/presentation/d/e/2PACX-1vT1zTUU36nekwbv7kKwPYTMn-CGbX-7B3Yfz_dzBmb0nOrkM1kqXBtDZRnFIXH_UNmhj2dbuY8gE8Ze/embed?start=true&loop=false&delayms=10000" frameborder="0" width="960" height="480" allowfullscreen="true" mozallowfullscreen="true" webkitallowfullscreen="true"></iframe>
+</div>
+
 #### Github Repo
 - @jwkanggist, [EveryBodyTensorFlow](https://github.com/jwkanggist/EveryBodyTensorFlow)
 - @jwkanggist, [부족한 LetNet5 TF model](https://github.com/jwkanggist/tensorflowlite)


### PR DESCRIPTION
스샷처럼 슬라이드 width가 튀어나오는 문제를 없앴습니다.
슬라이드를 넣을때는 아래처럼 iframe 태그 바깥에 스타일 태그와 div태그를 넣어 감싸주시면 되는데, 그냥 복붙하시면 될거에요. 아니면.. 제가 보다가 이상하다 싶으면 알아서 고쳐넣겠습니다.
```
<style>
.responsive-wrap iframe{ max-width: 100%;}
</style>
<div class="responsive-wrap">
<!-- this is the embed code provided by Google -->

<iframe src="https://docs.google.com/presentation/d/e/2PACX-1vT1zTUU36nekwbv7kKwPYTMn-CGbX-7B3Yfz_dzBmb0nOrkM1kqXBtDZRnFIXH_UNmhj2dbuY8gE8Ze/embed?start=true&loop=false&delayms=10000" frameborder="0" width="960" height="480" allowfullscreen="true" mozallowfullscreen="true" webkitallowfullscreen="true"></iframe>

</div>
```

![image](https://user-images.githubusercontent.com/37643248/41581042-275f5d68-73d8-11e8-8542-4f5589bc7e61.png)
